### PR TITLE
Style guide: .editorconfig and .prettierrc.json in source folder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[package.json]
+indent_style = space
+indent_size = 2
+
+[source/**.ts]
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,13 @@
 root = true
 
 [package.json]
-indent_style = space
-indent_size = 2
+indent_style = tab
+indent_size = 4
 
 [source/**.ts]
 end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = space
+indent_style = tab
 indent_size = 4

--- a/source/.prettierrc.json
+++ b/source/.prettierrc.json
@@ -3,5 +3,5 @@
   "tabWidth": 4,
   "endOfLine": "crlf",
   "printWidth": 80,
-  "useTabs": false
+  "useTabs": true
 }

--- a/source/.prettierrc.json
+++ b/source/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "none",
+  "tabWidth": 4,
+  "endOfLine": "crlf",
+  "printWidth": 80,
+  "useTabs": false
+}


### PR DESCRIPTION
Just an example style guide for us to consider. Most files are 4-space and CRLF, so I followed that. 
If we can agree on this style then I'll pull it into my working branch.

My personal opinion: [Tabs Are Clearly Superior](https://lea.verou.me/2012/01/why-tabs-are-clearly-superior/)